### PR TITLE
Update registration URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ With this Gem it is possible to order pre-paid shipping stickers from the Deutsc
 
 https://portokasse.deutschepost.de/portokasse/#/
 
-https://www.deutschepost.de/de/i/internetmarke-porto-drucken/partner-werden.html
+https://www.deutschepost.de/formular-ima
 
 
 ## Installation


### PR DESCRIPTION
The old URL no longer works and leaves one clueless. Took me a while to find the new one, so I thought it might be useful to share it here.